### PR TITLE
feat: Allowing sidecar configurations in Kafka-connect

### DIFF
--- a/charts/kafka-connect/templates/deployment.yml
+++ b/charts/kafka-connect/templates/deployment.yml
@@ -67,6 +67,9 @@ spec:
           volumeMounts:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          {{- if .Values.sidecars }}
+          {{- toYaml .Values.sidecars | nindent 8 }}
+          {{- end }}
       {{- with .Values.extraVolumes }}
       volumes:
         {{- tpl (toYaml .) $ | nindent 8 }}

--- a/charts/kafka-connect/templates/deployment.yml
+++ b/charts/kafka-connect/templates/deployment.yml
@@ -68,7 +68,7 @@ spec:
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
           {{- if .Values.sidecars }}
-          {{- toYaml .Values.sidecars | nindent 8 }}
+          {{- toYaml .Values.sidecars | nindent 10 }}
           {{- end }}
       {{- with .Values.extraVolumes }}
       volumes:

--- a/charts/kafka-connect/values.yaml
+++ b/charts/kafka-connect/values.yaml
@@ -163,6 +163,22 @@ initContainers:
   #     - name: plugin
   #       mountPath: /usr/share/confluent-hub-components
 
+# Sidecar containers
+sidecars: []
+# - name: sidecar-example
+#   image: example/sidecar:latest
+#   imagePullPolicy: IfNotPresent
+#   resources:
+#     limits:
+#       cpu: 100m
+#       memory: 128Mi
+#     requests:
+#       cpu: 50m
+#       memory: 64Mi
+#   volumeMounts:
+#     - name: shared-data
+#       mountPath: /shared-data
+
 kafka:
   create: true
   fullnameOverride: kafka-connect-kafka


### PR DESCRIPTION
Allowing to insert sidecar containers into the Kafka-connect deployment, e.g. to use a jmx-prometheus-exporter for monitoring.